### PR TITLE
Remove unused imports

### DIFF
--- a/src/cluster.py
+++ b/src/cluster.py
@@ -1,7 +1,5 @@
 import numpy as np
-from numpy.random import rand
 from sklearn.mixture import GaussianMixture
-from scipy import stats
 from operator import itemgetter
 from collections import defaultdict
 import argparse

--- a/src/ins.py
+++ b/src/ins.py
@@ -1,6 +1,5 @@
 import pysam
 from pybedtools import BedTool
-import sys
 import os
 from .utils import create_tmp_file, parallel_process, combine_batch_results, reverse_complement, split_tasks
 from collections import defaultdict

--- a/src/tre.py
+++ b/src/tre.py
@@ -6,8 +6,8 @@ import os
 import re
 from .variant import Variant, Allele
 from collections import defaultdict, Counter
-from operator import itemgetter, attrgetter
-from .utils import split_tasks, parallel_process, combine_batch_results, create_tmp_file, reverse_complement, merge_spans, complement_spans, is_same_repeat
+from operator import itemgetter
+from .utils import split_tasks, parallel_process, combine_batch_results, create_tmp_file, merge_spans, complement_spans, is_same_repeat
 from .ins import INSFinder, INS
 import math
 import numpy as np

--- a/src/variant.py
+++ b/src/variant.py
@@ -1,8 +1,7 @@
 import numpy as np
-from collections import Counter, defaultdict
+from collections import Counter
 from operator import itemgetter
 from .vcf import VCF
-from .utils import is_same_repeat
 import copy
 
 class Variant:

--- a/src/vcf.py
+++ b/src/vcf.py
@@ -1,4 +1,3 @@
-import re
 from collections import defaultdict, Counter
 from operator import itemgetter
 

--- a/straglr.py
+++ b/straglr.py
@@ -5,7 +5,6 @@ from src.tre import TREFinder
 from src.version import __version__
 import sys
 import tempfile
-import os
 
 def parse_args():
     trf_args_meta = ('Match', 'Mismatch', 'Delta', 'PM', 'PI', 'Minscore', 'MaxPeriod')


### PR DESCRIPTION
This change removes unused imports. Pylint does not report more issues of that type.